### PR TITLE
Move draft instructions to a tooltip next to header

### DIFF
--- a/squad-draft/App.tsx
+++ b/squad-draft/App.tsx
@@ -163,7 +163,19 @@ const App: React.FC = () => {
             <span className="text-yellow-400"><i className="fas fa-trophy"></i></span>
             ULTIMATE 11
           </h1>
-          <p className="text-slate-400 font-medium">Daily Squad Draft Challenge</p>
+          <div className="flex items-center gap-2 relative group w-max">
+            <p className="text-slate-400 font-medium">Daily Squad Draft Challenge</p>
+            <i className="fas fa-info-circle text-slate-400 cursor-help transition-colors hover:text-slate-300"></i>
+
+            <div className="absolute left-0 top-full mt-2 w-72 bg-slate-800 rounded-xl p-4 border border-slate-700 shadow-xl opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50 pointer-events-none">
+              <h4 className="text-slate-400 text-xs font-bold uppercase mb-2">Instructions</h4>
+              <ul className="text-xs text-slate-300 space-y-1.5 list-disc pl-4">
+                <li>Choose ONE player from each daily squad</li>
+                <li>Assign them to a specific spot on your formation</li>
+                <li>Balanced positions lead to higher team synergy</li>
+              </ul>
+            </div>
+          </div>
         </div>
 
         <div className="flex gap-2">
@@ -250,15 +262,6 @@ const App: React.FC = () => {
                   </button>
                 </div>
               )}
-
-              <div className="bg-slate-800/30 rounded-xl p-4 border border-dashed border-slate-700">
-                <h4 className="text-slate-400 text-xs font-bold uppercase mb-2">Instructions</h4>
-                <ul className="text-xs text-slate-500 space-y-1">
-                  <li>• Choose ONE player from each daily squad</li>
-                  <li>• Assign them to a specific spot on your formation</li>
-                  <li>• Balanced positions lead to higher team synergy</li>
-                </ul>
-              </div>
             </div>
 
             {/* Pitch Visualization Area */}


### PR DESCRIPTION
This pull request moves the draft instructions from the main draft interface into a hover tooltip next to the "Daily Squad Draft Challenge" header.

**Changes:**
- Added a FontAwesome info icon (`fa-info-circle`) next to the header text.
- Implemented a hover tooltip using Tailwind CSS `group` and `absolute` classes to display the instructions.
- Removed the static instructions block that took up space in the main draft area.
- Converted the manual bullet points to a semantic `<ul>` with `list-disc`.

---
*PR created automatically by Jules for task [17613712134435252983](https://jules.google.com/task/17613712134435252983) started by @seanr89*