### PR TITLE
feat: Add Daily Leaderboard UI screen with test data

### DIFF
--- a/squad-draft/App.tsx
+++ b/squad-draft/App.tsx
@@ -6,9 +6,10 @@ import { fetchDailySquads } from './api';
 import Pitch from './components/Pitch';
 import PlayerCard from './components/PlayerCard';
 import AboutDialog from './components/AboutDialog';
+import Leaderboard from './components/Leaderboard';
 
 const App: React.FC = () => {
-  const [view, setView] = useState<'draft' | 'team'>('draft');
+  const [view, setView] = useState<'draft' | 'team' | 'leaderboard'>('draft');
   const [isAboutOpen, setIsAboutOpen] = useState(false);
   const [squads, setSquads] = useState<Squad[]>([]);
   const [loading, setLoading] = useState(true);
@@ -221,6 +222,12 @@ const App: React.FC = () => {
           >
             <i className="fas fa-tshirt mr-2"></i> My Team
           </button>
+          <button
+            onClick={() => setView('leaderboard')}
+            className={`px-4 py-2 rounded-lg font-bold transition-all ${view === 'leaderboard' ? 'bg-yellow-400 text-slate-900 shadow-lg shadow-yellow-400/20' : 'bg-slate-800 text-slate-300 hover:bg-slate-700'}`}
+          >
+            <i className="fas fa-list-ol mr-2"></i> Leaderboard
+          </button>
         </div>
       </header>
 
@@ -233,7 +240,7 @@ const App: React.FC = () => {
           </div>
         )}
 
-        {!loading && error && (
+        {!loading && error && view !== 'leaderboard' && (
           <div className="flex flex-col items-center justify-center p-12 text-center max-w-lg mx-auto">
             <div className="bg-red-500/10 text-red-400 p-8 rounded-2xl border border-red-500/20 shadow-lg shadow-red-500/10 w-full">
               <i className="fas fa-exclamation-triangle text-5xl mb-6 text-red-500"></i>
@@ -249,6 +256,10 @@ const App: React.FC = () => {
               </button>
             </div>
           </div>
+        )}
+
+        {!loading && view === 'leaderboard' && (
+          <Leaderboard />
         )}
 
         {!loading && !error && currentSquad && view === 'draft' && !draft.completed && (
@@ -389,6 +400,13 @@ const App: React.FC = () => {
           >
             <i className="fas fa-tshirt"></i>
             <span className="text-[10px] font-bold uppercase">Team</span>
+          </button>
+          <button
+            onClick={() => setView('leaderboard')}
+            className={`flex flex-col items-center gap-1 ${view === 'leaderboard' ? 'text-yellow-400' : 'text-slate-500'}`}
+          >
+            <i className="fas fa-list-ol"></i>
+            <span className="text-[10px] font-bold uppercase">Ranks</span>
           </button>
         </div>
       </footer>

--- a/squad-draft/components/Leaderboard.tsx
+++ b/squad-draft/components/Leaderboard.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import { Player } from '../types';
+
+interface LeaderboardEntry {
+  id: string;
+  playerName: string;
+  teamAverageRating: number;
+  squad: Player[];
+}
+
+const TEST_DATA: LeaderboardEntry[] = [
+  {
+    id: '1',
+    playerName: 'Alex',
+    teamAverageRating: 92.5,
+    squad: []
+  },
+  {
+    id: '2',
+    playerName: 'Jordan',
+    teamAverageRating: 91.2,
+    squad: []
+  },
+  {
+    id: '3',
+    playerName: 'Taylor',
+    teamAverageRating: 89.8,
+    squad: []
+  },
+  {
+    id: '4',
+    playerName: 'Morgan',
+    teamAverageRating: 88.5,
+    squad: []
+  },
+  {
+    id: '5',
+    playerName: 'Casey',
+    teamAverageRating: 87.9,
+    squad: []
+  }
+];
+
+const Leaderboard: React.FC = () => {
+  const [selectedEntry, setSelectedEntry] = useState<LeaderboardEntry | null>(null);
+
+  const closeDialog = () => {
+    setSelectedEntry(null);
+  };
+
+  return (
+    <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 w-full max-w-4xl mx-auto">
+      <div className="bg-slate-800/80 rounded-2xl p-6 border border-slate-700 shadow-xl">
+        <h2 className="text-2xl font-extrabold text-white mb-6 flex items-center gap-3">
+          <i className="fas fa-list-ol text-yellow-400"></i>
+          Daily Leaderboard
+        </h2>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-left border-collapse">
+            <thead>
+              <tr className="border-b border-slate-700 text-slate-400 text-xs uppercase tracking-wider">
+                <th className="p-4 font-bold">Rank</th>
+                <th className="p-4 font-bold">Player</th>
+                <th className="p-4 font-bold text-center">Avg Rating</th>
+                <th className="p-4 font-bold text-center">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {TEST_DATA.map((entry, index) => (
+                <tr
+                  key={entry.id}
+                  className={`border-b border-slate-700/50 hover:bg-slate-700/30 transition-colors ${
+                    index === 0 ? 'bg-yellow-400/5' :
+                    index === 1 ? 'bg-slate-300/5' :
+                    index === 2 ? 'bg-amber-600/5' : ''
+                  }`}
+                >
+                  <td className="p-4">
+                    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-slate-800 border border-slate-600 font-bold text-white shadow-inner">
+                      {index + 1}
+                    </div>
+                  </td>
+                  <td className="p-4 font-bold text-white text-lg">{entry.playerName}</td>
+                  <td className="p-4 text-center">
+                    <span className="inline-block px-3 py-1 rounded-full bg-slate-800 border border-slate-600 font-black text-yellow-400">
+                      {entry.teamAverageRating.toFixed(1)}
+                    </span>
+                  </td>
+                  <td className="p-4 text-center">
+                    <button
+                      onClick={() => setSelectedEntry(entry)}
+                      className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-lg font-bold transition-all shadow-md hover:shadow-lg text-sm"
+                    >
+                      <i className="fas fa-eye mr-2"></i> View Squad
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Placeholder Dialog */}
+      {selectedEntry && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-slate-900/80 backdrop-blur-sm" onClick={closeDialog} />
+
+          <div className="relative w-full max-w-lg bg-slate-800 rounded-2xl border border-slate-700 shadow-2xl flex flex-col overflow-hidden max-h-[85vh]">
+            <div className="flex items-center justify-between p-4 md:p-6 border-b border-slate-700">
+              <h3 className="text-xl font-bold text-white flex items-center gap-2">
+                <i className="fas fa-users text-yellow-400"></i>
+                {selectedEntry.playerName}'s Squad
+              </h3>
+              <button
+                onClick={closeDialog}
+                className="text-slate-400 hover:text-white transition-colors w-8 h-8 flex items-center justify-center rounded-lg hover:bg-slate-700"
+              >
+                <i className="fas fa-times"></i>
+              </button>
+            </div>
+
+            <div className="p-6 overflow-y-auto">
+              <div className="flex justify-center mb-6">
+                 <div className="flex flex-col items-center gap-2">
+                    <div className="text-4xl font-black text-yellow-400">{selectedEntry.teamAverageRating.toFixed(1)}</div>
+                    <div className="text-xs text-slate-400 font-bold uppercase tracking-widest">Team Rating</div>
+                 </div>
+              </div>
+
+              <div className="bg-slate-700/30 rounded-xl p-8 border border-slate-600 flex flex-col items-center justify-center text-center">
+                 <i className="fas fa-tools text-4xl text-slate-500 mb-4"></i>
+                 <p className="text-slate-300 font-medium">Squad details visualization coming soon.</p>
+                 <p className="text-slate-500 text-sm mt-2">Currently showing placeholder data.</p>
+              </div>
+            </div>
+
+            <div className="p-4 border-t border-slate-700 bg-slate-800/50 flex justify-end">
+               <button
+                onClick={closeDialog}
+                className="px-6 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-xl font-bold transition-all"
+               >
+                 Close
+               </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Leaderboard;


### PR DESCRIPTION
Added a Daily Leaderboard UI to show top players with a "View Squad" action opening a details dialog. Used mocked test data for presentation. Integration with the main App view state for seamless navigation.

---
*PR created automatically by Jules for task [5577279648511284296](https://jules.google.com/task/5577279648511284296) started by @seanr89*