### PR TITLE
feat(ui): add team screenshot export functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 fixture.json
 squad-draft/.env
+squad-draft/.env

--- a/squad-draft/App.tsx
+++ b/squad-draft/App.tsx
@@ -1,5 +1,6 @@
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
+import html2canvas from 'html2canvas';
 import { INITIAL_FORMATION, generateFormationSpots } from './constants';
 import { DraftState, Player, Squad, FormationSpot, Position } from './types';
 import { fetchDailySquads } from './api';
@@ -9,6 +10,7 @@ import AboutDialog from './components/AboutDialog';
 import Leaderboard from './components/Leaderboard';
 
 const App: React.FC = () => {
+  const teamRef = useRef<HTMLDivElement>(null);
   const [view, setView] = useState<'draft' | 'team' | 'leaderboard'>('draft');
   const [isAboutOpen, setIsAboutOpen] = useState(false);
   const [squads, setSquads] = useState<Squad[]>([]);
@@ -165,6 +167,26 @@ const App: React.FC = () => {
 
     setTempPlayer(null);
     setActiveSpotId(null);
+  };
+
+  const exportTeamScreenshot = async () => {
+    if (!teamRef.current) return;
+
+    try {
+      const canvas = await html2canvas(teamRef.current, {
+        backgroundColor: '#0f172a', // Tailwind slate-900 to match background
+        scale: 2, // Higher quality
+        useCORS: true, // Required for fetching external player images
+      });
+
+      const image = canvas.toDataURL('image/png');
+      const link = document.createElement('a');
+      link.href = image;
+      link.download = `ultimate-11-team-${new Date().toISOString().split('T')[0]}.png`;
+      link.click();
+    } catch (err) {
+      console.error('Failed to export screenshot', err);
+    }
   };
 
   const cancelSelection = () => {
@@ -337,7 +359,7 @@ const App: React.FC = () => {
         {!loading && !error && (view === 'team' || draft.completed) && (
           <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
             <div className="flex flex-col md:flex-row gap-8">
-              <div className="md:w-2/3">
+              <div ref={teamRef} className="md:w-2/3">
                 <Pitch formation={draft.formation} activeSpotId={null} />
               </div>
 
@@ -361,6 +383,12 @@ const App: React.FC = () => {
                       <p className="text-xs opacity-80">You've built an incredible squad of legends.</p>
                     </div>
                   )}
+                  <button
+                    onClick={exportTeamScreenshot}
+                    className="w-full py-3 px-4 bg-blue-500/10 border border-blue-500/20 text-blue-400 rounded-xl font-bold hover:bg-blue-500 hover:text-white transition-all flex items-center justify-center gap-2 mb-4"
+                  >
+                    <i className="fas fa-camera"></i> Export Screenshot
+                  </button>
                   <button
                     onClick={resetDraft}
                     className="w-full py-3 px-4 bg-red-500/10 border border-red-500/20 text-red-500 rounded-xl font-bold hover:bg-red-500 hover:text-white transition-all flex items-center justify-center gap-2"

--- a/squad-draft/package-lock.json
+++ b/squad-draft/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ultimate-11:-squad-draft",
       "version": "0.0.0",
       "dependencies": {
+        "html2canvas": "^1.4.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3"
       },
@@ -1232,6 +1233,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
@@ -1303,6 +1313,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1422,6 +1441,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -1651,6 +1683,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -1718,6 +1759,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/squad-draft/package.json
+++ b/squad-draft/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "html2canvas": "^1.4.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },


### PR DESCRIPTION
# What does this PR do?
Adds a new feature to the Team view that allows users to export a screenshot of their completed draft or current team.

# How to verify
1. Navigate to the app.
2. Complete a draft or click on "My Team".
3. Under the "Team Performance" section, click on the new "Export Screenshot" button.
4. Verify that a PNG file is downloaded with the rendered pitch.

---
*PR created automatically by Jules for task [15349268232976755487](https://jules.google.com/task/15349268232976755487) started by @seanr89*